### PR TITLE
Extra declaration to allow building inside a custom framework

### DIFF
--- a/Source/ECAssertion.h
+++ b/Source/ECAssertion.h
@@ -1,0 +1,57 @@
+// --------------------------------------------------------------------------
+//! @author Sam Deane
+//! @date 12/04/2011
+//
+//  Copyright 2012 Sam Deane, Elegant Chaos. All rights reserved.
+//  This source code is distributed under the terms of Elegant Chaos's 
+//  liberal license: http://www.elegantchaos.com/license/liberal
+// --------------------------------------------------------------------------
+
+#ifdef __OBJC__
+#import <Foundation/Foundation.h>
+#endif
+
+#define ECAssertShouldntBeHereBase(imp)							imp(FALSE)
+#define ECAssertNonNilBase(expression, imp)						imp((expression) != nil)
+#define ECAssertNilBase(expression, imp)						imp((expression) == nil)
+#define ECAssertCountAtLeastBase(container, countMinimum, imp)	imp([container count] >= countMinimum)
+#define ECAssertEmptyBase(object, imp)							
+
+#if EC_DEBUG
+
+#import "ECLoggingMacros.h"
+
+ECDeclareDebugChannel(AssertionChannel);
+
+#define ECAssert(expression) do { if (!(expression)) { ECDebug(AssertionChannel, @"Expression %s was false", #expression); [ECAssertion failAssertion:#expression]; } } while(0)
+#define ECAssertC(expression) assert(expression)
+
+#else // NON-DEBUG
+
+#define ECAssert(expression)
+#define ECAssertC(expression)
+
+#endif
+
+#define ECAssertShouldntBeHere() ECAssertShouldntBeHereBase(ECAssert)
+#define ECAssertShouldntBeHereC() ECAssertShouldntBeHereBase(ECAssertC)
+
+#define ECAssertNonNil(expression) ECAssertNonNilBase(expression, ECAssert)
+#define ECAssertNonNilC(expression) ECAssertNonNilBase(expression, ECAssertC)
+
+#define ECAssertNil(expression) ECAssertNilBase(expression, ECAssert)
+#define ECAssertNilC(expression) ECAssertNilBase(expression, ECAssertC)
+
+#define ECAssertCountAtLeast(container, countMinimum) ECAssertCountAtLeastBase(container, countMinimum, ECAssert)
+#define ECAssertCountAtLeastC(container, countMinimum) ECAssertCountAtLeastBase(container, countMinimum, ECAssertC)
+
+#define ECAssertEmpty(item) do { if ([item respondsToSelector:@selector(length)]) { ECAssert([(NSString*) item length] == 0); } else { ECAssert([item count] == 0); } } while (0)
+
+#define ECAssertIsKindOfClass(o, c) ECAssert([o isKindOfClass:[c class]])
+#define ECAssertIsMemberOfClass(o, c) ECAssert([o isMemberOfClass:[c class]])
+
+@interface ECAssertion : NSObject
+
++ (void)failAssertion:(const char*)expression;
+
+@end

--- a/Source/ECLogContext.h
+++ b/Source/ECLogContext.h
@@ -1,0 +1,61 @@
+// --------------------------------------------------------------------------
+//! @author Sam Deane
+//! @date 12/04/2011
+//
+//  Copyright 2012 Sam Deane, Elegant Chaos. All rights reserved.
+//  This source code is distributed under the terms of Elegant Chaos's 
+//  liberal license: http://www.elegantchaos.com/license/liberal
+// --------------------------------------------------------------------------
+
+#include <stdbool.h>
+#ifdef __OBJC__
+
+#import <Foundation/Foundation.h>
+@class ECLogChannel;
+
+#else
+
+typedef void ECLogChannel;
+
+#endif
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+    
+    typedef enum
+    {
+        ECLogContextNone        = 0x0000,
+        ECLogContextFile        = 0x0001,
+        ECLogContextDate        = 0x0002,
+        ECLogContextFunction    = 0x0004,
+        ECLogContextMessage     = 0x0008,
+        ECLogContextName        = 0x0010,
+        
+        ECLogContextFullPath    = 0x1000,
+        ECLogContextDefault     = 0x8000
+    } ECLogContextFlags;
+    
+    typedef struct 
+    {
+        const char* file;
+        unsigned int line;
+        const char* date;
+        const char* function;
+    } ECLogContext;
+    
+    extern void makeContext(ECLogContext* context, const char* file, unsigned int line, const char* date, const char* function);
+    extern void enableChannel(ECLogChannel* channel);
+    extern void disableChannel(ECLogChannel* channel);
+    extern bool channelEnabled(ECLogChannel* channel);
+    extern ECLogChannel* registerChannel(const char* name);
+    extern ECLogChannel* registerChannelWithOptions(const char* name, id options);
+    extern void	logToChannel(ECLogChannel* channel, ECLogContext* context, id object, ...);
+    
+#ifdef __cplusplus
+}
+#endif
+
+#define ECMakeContext() ECLogContext ecLogContext; makeContext(&ecLogContext, __FILE__, __LINE__, __DATE__, __PRETTY_FUNCTION__)
+


### PR DESCRIPTION
I have included ECLogging inside a custom framework. In that context it could not properly find CoreFoundation objects.
To solve my compilation problem I had to explicitly declare that I need Foundation.h.

I submit this for review / advice / discussion.
The patch might need change to support framework inclusion on MacOSX instead of iOS.
