### PR TITLE
Fix compile errors when embedding in custom framework

### DIFF
--- a/Source/Generic/ECAssertion.h
+++ b/Source/Generic/ECAssertion.h
@@ -7,6 +7,10 @@
 //  liberal license: http://www.elegantchaos.com/license/liberal
 // --------------------------------------------------------------------------
 
+#ifdef __OBJC__
+#import <Foundation/Foundation.h>
+#endif
+
 #define ECAssertShouldntBeHereBase(imp)							imp(FALSE)
 #define ECAssertNonNilBase(expression, imp)						imp((expression) != nil)
 #define ECAssertNilBase(expression, imp)						imp((expression) == nil)

--- a/Source/Generic/ECLogContext.h
+++ b/Source/Generic/ECLogContext.h
@@ -7,8 +7,11 @@
 //  liberal license: http://www.elegantchaos.com/license/liberal
 // --------------------------------------------------------------------------
 
+#include <stdbool.h>
+
 #ifdef __OBJC__
 
+#import <Foundation/Foundation.h>
 @class ECLogChannel;
 
 #else


### PR DESCRIPTION
I have included ECLogging inside a custom framework. In that context it could not properly find CoreFoundation objects.
To solve my compilation problem I had to explicitly declare that I need Foundation.h.

I submit this for review / advice / discussion.

(Sorry for previous error in pull request).
